### PR TITLE
Grid Match Identifier and Token Shuffler

### DIFF
--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -33,6 +33,10 @@ export class Column extends Container{
         }
     }
 
+    public getAllTokens(): Token[] {
+        return this.tokens;
+    }
+
     public getToken(Y: number) {
         return this.tokens[Y];
     }

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -44,7 +44,7 @@ export class Grid extends Container {
         //console.log("tokenX: ", tokenX, "tokenY", tokenY, "ActiveToken: ", this.activeToken);
 
         const location = [tokenX, tokenY];
-
+        this.matchCheck(location);
 
         // if(this.activeToken === 0) {
         //     this.activeToken = 1; 
@@ -97,6 +97,8 @@ export class Grid extends Container {
             yMatches.push(this.getToken(originX, i))
         }
 
+        console.log(xMatches, yMatches);
+
         if(xMatches.length >= 3) {this.purgeTokens(xMatches)}
         if(yMatches.length >= 3) {this.purgeTokens(yMatches)}
         if( (xMatches.length >= 3) || (yMatches.length >= 3)) {this.nukeBoard();}
@@ -124,7 +126,6 @@ export class Grid extends Container {
     }
 
     private nukeBoard(): void {
-        console.log("KABOOM");
 
         function isMatched(token: Token) {
             return (token.matched);
@@ -150,9 +151,10 @@ export class Grid extends Container {
             });
             for(var i = 0; i <= 5; i++){
                 const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
-                newColumn[i].setSkIndex(randomNumber);
             }
         });
+
+        console.log("KABOOM");
 
     }
 

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -96,15 +96,59 @@ export class Grid extends Container {
             yMatches.push(this.getToken(originX, i))
         }
 
+        if(xMatches.length >= 3) {this.purgeTokens(xMatches)}
+        if(yMatches.length >= 3) {this.purgeTokens(yMatches)}
+        if( (xMatches.length >= 3) || (yMatches.length >= 3)) {this.nukeBoard();}
+
     }
 
     private getToken(X: number, Y: number): Token {
         return this.columns[X].getToken(Y);
     }
 
+    private purgeTokens(inputTokens: Token[]): void {
+        inputTokens.forEach(element => {
+            element.matched = true;
+            console.log(element.matched)
+        });
+    }
+
     private isMatch(originToken: Token, comparisonToken: Token): boolean {
         if(originToken.getSkIndex() === comparisonToken.getSkIndex()) {return true;}
         else return false;
+    }
+
+    private nukeBoard(): void {
+        console.log("KABOOM");
+
+        function isMatched(token: Token) {
+            return (token.matched);
+        }
+
+        function isNotMatched(token: Token) {
+            return (!token.matched);
+        }
+
+        this.columns.forEach(column => {
+            let unmatched = column.getAllTokens().filter(isNotMatched);
+            let matched = column.getAllTokens().filter(isMatched);
+            matched.forEach(token => {
+                token.shuffleSkin();
+            });
+            let newColumn: Token [];
+            newColumn = [];
+            matched.forEach(token => {
+                newColumn.push(token);
+            });
+            unmatched.forEach(token => {
+                newColumn.push(token);
+            });
+            for(var i = 0; i <= 5; i++){
+                const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
+                newColumn[i].setSkIndex(randomNumber);
+            }
+        });
+
     }
 
     // private checkMatch(): void {

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -41,7 +41,6 @@ export class Grid extends Container {
         if(this.activeToken === undefined) {
             this.activeToken = 0;
         }
-        //console.log("tokenX: ", tokenX, "tokenY", tokenY, "ActiveToken: ", this.activeToken);
 
         const location = [tokenX, tokenY];
         this.matchCheck(location);
@@ -75,33 +74,45 @@ export class Grid extends Container {
 
         //check token's right
         for(let i = originX+1; i <= this.gridSize-1; i++) {
-            if(!this.isMatch(origin, this.getToken(i, originY))) {break;}
+            if(!this.isMatch(origin, this.getToken(i, originY))) {
+                break;
+            }
             xMatches.push(this.getToken(i, originY))
         }
 
         //token's left
         for(let i = originX-1; i >= 0; i--) {
-            if(!this.isMatch(origin, this.getToken(i, originY))) {break;}
+            if(!this.isMatch(origin, this.getToken(i, originY))) {
+                break;
+            }
             xMatches.push(this.getToken(i, originY))
         }
 
         //beneath token
         for(let i = originY+1; i <= this.gridSize-1; i++) {
-            if(!this.isMatch(origin, this.getToken(originX, i))) {break;}
+            if(!this.isMatch(origin, this.getToken(originX, i))) {
+                break;
+            }
             yMatches.push(this.getToken(originX, i))
         }
 
         //above token
         for(let i = originY-1; i >= 0; i--) {
-            if(!this.isMatch(origin, this.getToken(originX, i))) {break;}
+            if(!this.isMatch(origin, this.getToken(originX, i))) {
+                break;
+            }
             yMatches.push(this.getToken(originX, i))
         }
 
-        console.log(xMatches, yMatches);
-
-        if(xMatches.length >= 3) {this.purgeTokens(xMatches)}
-        if(yMatches.length >= 3) {this.purgeTokens(yMatches)}
-        if( (xMatches.length >= 3) || (yMatches.length >= 3)) {this.nukeBoard();}
+        if(xMatches.length >= 3) {
+            this.purgeTokens(xMatches)
+        }
+        if(yMatches.length >= 3) {
+            this.purgeTokens(yMatches)
+        }
+        if( (xMatches.length >= 3) || (yMatches.length >= 3)) {
+            this.nukeBoard();
+        }
 
     }
 
@@ -112,7 +123,6 @@ export class Grid extends Container {
     private purgeTokens(inputTokens: Token[]): void {
         inputTokens.forEach(element => {
             element.matched = true;
-            console.log(element.matched)
         });
     }
 
@@ -136,25 +146,19 @@ export class Grid extends Container {
         }
 
         this.columns.forEach(column => {
-            let unmatched = column.getAllTokens().filter(isNotMatched);
-            let matched = column.getAllTokens().filter(isMatched);
+            const unmatched = column.getAllTokens().filter(isNotMatched);
+            const matched = column.getAllTokens().filter(isMatched);
             matched.forEach(token => {
                 token.shuffleSkin();
             });
-            let newColumn: Token [];
-            newColumn = [];
+            const newColumn = column.getAllTokens();
             matched.forEach(token => {
                 newColumn.push(token);
             });
             unmatched.forEach(token => {
                 newColumn.push(token);
             });
-            for(var i = 0; i <= 5; i++){
-                const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
-            }
         });
-
-        console.log("KABOOM");
 
     }
 

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -6,6 +6,7 @@ import { eventEmitter } from "../../../event-emitter";
 
 export class Token extends Container {
 
+    public matched: boolean;
     private parentID: number;
     private locationIndex;
     private skin: Spine;
@@ -19,7 +20,7 @@ export class Token extends Container {
         //eventEmitter.on('tokenFirstClicked', this.onClicked);
         //eventEmitter.on('tokenSecondClicked', this.onClicked);
 
-
+        this.matched = false;
         this.interactive = true;
         this.parentID = parentID;
         this.locationIndex = locationIndex;
@@ -48,6 +49,16 @@ export class Token extends Container {
 
     public getSkIndex(): number {
         return this.skIndex;
+    }
+
+    public setSkIndex(newSkIndex: number): void {
+        this.skIndex = newSkIndex;
+    }
+
+    public shuffleSkin(): void {
+        const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
+        this.skIndex = randomNumber;
+        this.skin.skeleton.setSkinByName(`${this.skIndex}`);
     }
 
     // private wobble(): void {


### PR DESCRIPTION
Added matchCheck and supporting changes to allow the board to check for matches of at least 3 of a kind.

Function triggers on first click at the moment. On finding 3 adjacent tokens (horizontal or vertical) the board reassembles an array with the matching tokens' skins randomised.

The searching and shuffling should be limited to the grid level with accessors added to Column and Token to facilitate the feature.