### PR TITLE
Columns use held Token match status to Tween to new positions

### DIFF
--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -52,4 +52,41 @@ export class Column extends Container{
         return this.tokens[Y];
     }
 
+    public veryCoolTokenReplacement(): void {
+
+        this.tokens.forEach(token => {
+            if(token.matched) {
+                token.hide();
+            }
+        })
+
+
+        function isMatched(token: Token) {
+            return (token.matched);
+        }
+
+        function isNotMatched(token: Token) {
+            return (!token.matched);
+        }
+        
+        const newTokenArray = this.getAllTokens();
+
+        const matched = this.getAllTokens().filter(isMatched);
+        matched.forEach(token => {
+            token.shuffleSkin();
+            newTokenArray.push(token);
+        });
+
+        const unmatched = this.getAllTokens().filter(isNotMatched);
+        unmatched.forEach(token => {
+            newTokenArray.push(token);
+        });
+
+        newTokenArray.forEach(token => {
+            token.matched = false;
+        })
+
+        this.replaceAllTokens(newTokenArray);
+}
+
 }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -7,22 +7,100 @@ export class Column extends Container{
     public tokens: Token[] = [];
     private columnID: number;
     private columnSize: number;
+    private availHeight: number;
 
     constructor(columnID: number, columnSize: number, availWidth: number, availHeight: number) {
         super()
 
         this.columnID = columnID;
         this.columnSize = columnSize;
+        this.availHeight = availHeight;
 
         for(var i = 0; i < this.columnSize; i++) {
             const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
 
-            const newToken = new Token(this.columnID, i, this.columnSize, randomNumber, availWidth)
-            newToken.y = (availHeight / (columnSize/i));
+            const newToken = new Token(this.columnID, i, this.columnSize, randomNumber, availWidth, availHeight)
+            newToken.y = (availHeight / (this.columnSize/i));
 
             this.tokens.push(newToken);
             this.addChild(newToken);
         }
+    }
+
+    public processMatches(): void {
+            const matchedTokens: Token [] = [];
+            const unmatchedTokens: Token [] = [];
+
+            //this.hideMatches();
+            
+            //build an array of matched tokens and an array of unmatched tokens
+            for(let i = 0; i < this.tokens.length; i++) {
+                const target = this.tokens[i]
+                if(target.matched) {
+                    target.shuffleSkin();
+                    target.hide();
+                    matchedTokens.push(target);
+                }
+
+                if(!target.matched) {
+                    unmatchedTokens.push(target);
+                }
+            }
+
+            //the unmatched tokens on the screen
+            //find coordinate of the place to move to
+            for(let columnInspector: number = 0; columnInspector < this.tokens.length-1; columnInspector++) {
+
+                if(//columnInspector+1 <= this.tokens.length-1 
+                     !this.tokens[columnInspector].matched 
+                    ) {
+                        console.log("columnInspector: ", columnInspector);
+                        let combo = columnInspector+1;
+                        for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
+                            if(!this.tokens[combo].matched) { 
+                                break; 
+                            }
+                            else 
+                                console.log("combo: ", combo);
+                                this.tokens[columnInspector].moveTo(combo);
+                        }
+                }
+            }
+            //tween there
+
+            this.tokens.forEach(token => {
+                token.matched = false;
+            })
+
+            // this.tokens = [...matchedTokens, ...unmatchedTokens];
+            // console.log(this.tokens);
+            // for(var i = 0; i < this.columnSize; i++) {
+            //     this.tokens[i].y = (this.availHeight / (this.columnSize/i));
+            //     this.tokens[i]._verticalIndex = i;
+            // }
+
+            //this.revealMatches();
+    }
+
+    public hideMatches(): void {
+        this.tokens.forEach(token => {
+            if(token.matched) {
+                token.hide()
+            }
+        });
+    }
+
+    public revealMatches(): void {
+        this.tokens.forEach(token => {
+            if(token.matched) {
+                token.reveal()
+                token.matched = false;
+            }
+        });
+    }
+
+    public getToken(Y: number) {
+        return this.tokens[Y];
     }
 
     public removeAllTokens(): void {
@@ -35,7 +113,4 @@ export class Column extends Container{
         }
     }
 
-    public getToken(Y: number) {
-        return this.tokens[Y];
-    }
 }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -40,13 +40,11 @@ export class Column extends Container{
             if(!target.matched) {
                 nonMatchCombo.unshift(target);
                 for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
+                    if(this.tokens[combo].matched){ break; }
                     if(this.tokens[combo].matched) { 
                         for(let i = 0; i < nonMatchCombo.length; i++){
                             nonMatchCombo[i].moveTo(combo-i);
                         }
-                    }
-                    else {
-                        break;
                     }
                 }
             }
@@ -64,7 +62,7 @@ export class Column extends Container{
                 matchedTokens.push(target);
             }
 
-            if(!target.matched) {
+            else {
                 unmatchedTokens.push(target);
             }
         }
@@ -88,7 +86,6 @@ export class Column extends Container{
         this.tokens.forEach(token => {
             if(token.matched) {
                 token.reveal()
-                token.matched = false;
             }
         });
     }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -4,11 +4,9 @@ import { Token } from "./token";
 
 export class Column extends Container{
 
-    private tokens: Token[];
+    public tokens: Token[];
     private columnID: number;
     private columnSize: number;
-    // private viewWidth: number;
-    // private viewHeight: number;
 
 
     constructor(columnID: number, columnSize: number, availWidth: number, availHeight: number) {
@@ -16,25 +14,17 @@ export class Column extends Container{
 
         this.columnID = columnID;
         this.columnSize = columnSize;
-        // this.viewWidth = viewWidth;
-        // this.viewHeight = viewHeight;
 
         this.tokens = [];
         for(var i = 0; i < this.columnSize; i++) {
             const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
 
-            //const newToken = new Token(ran, this.columnID, availWidth, columnSize,);
-            //parentID: number, locationIndex: number, size: number, skIndex: number, availWidth: number
             const newToken = new Token(this.columnID, i, this.columnSize, randomNumber, availWidth)
             newToken.y = (availHeight / (columnSize/i));
 
             this.tokens.push(newToken);
             this.addChild(newToken);
         }
-    }
-
-    public getAllTokens(): Token[] {
-        return this.tokens;
     }
 
     public removeAllTokens(): void {
@@ -47,46 +37,5 @@ export class Column extends Container{
             return;
         }
     }
-
-    public getToken(Y: number) {
-        return this.tokens[Y];
-    }
-
-    public veryCoolTokenReplacement(): void {
-
-        this.tokens.forEach(token => {
-            if(token.matched) {
-                token.hide();
-            }
-        })
-
-
-        function isMatched(token: Token) {
-            return (token.matched);
-        }
-
-        function isNotMatched(token: Token) {
-            return (!token.matched);
-        }
-        
-        const newTokenArray = this.getAllTokens();
-
-        const matched = this.getAllTokens().filter(isMatched);
-        matched.forEach(token => {
-            token.shuffleSkin();
-            newTokenArray.push(token);
-        });
-
-        const unmatched = this.getAllTokens().filter(isNotMatched);
-        unmatched.forEach(token => {
-            newTokenArray.push(token);
-        });
-
-        newTokenArray.forEach(token => {
-            token.matched = false;
-        })
-
-        this.replaceAllTokens(newTokenArray);
-}
 
 }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -100,8 +100,4 @@ export class Column extends Container{
             return;
         }
     }
-
-    public getToken(Y: number) {
-        return this.tokens[Y];
-    }
 }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -8,7 +8,6 @@ export class Column extends Container{
     private columnID: number;
     private columnSize: number;
 
-
     constructor(columnID: number, columnSize: number, availWidth: number, availHeight: number) {
         super()
 
@@ -25,9 +24,6 @@ export class Column extends Container{
             this.addChild(newToken);
         }
     }
-
-
-
 
     public removeAllTokens(): void {
         this.tokens = [];

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -1,7 +1,6 @@
 import { Container } from "pixi.js";
 import { Token } from "./token";
 
-
 export class Column extends Container{
 
     public tokens: Token[] = [];
@@ -30,8 +29,6 @@ export class Column extends Container{
     public processMatches(): void {
             const matchedTokens: Token [] = [];
             const unmatchedTokens: Token [] = [];
-
-            //this.hideMatches();
             
             //build an array of matched tokens and an array of unmatched tokens
             for(let i = 0; i < this.tokens.length; i++) {
@@ -47,39 +44,25 @@ export class Column extends Container{
                 }
             }
 
-            //the unmatched tokens on the screen
-            //find coordinate of the place to move to
+            //move tokens from original positions in to the furthest matched token position
             for(let columnInspector: number = 0; columnInspector < this.tokens.length-1; columnInspector++) {
-
-                if(//columnInspector+1 <= this.tokens.length-1 
-                     !this.tokens[columnInspector].matched 
-                    ) {
-                        console.log("columnInspector: ", columnInspector);
-                        let combo = columnInspector+1;
-                        for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
-                            if(!this.tokens[combo].matched) { 
-                                break; 
-                            }
-                            else 
-                                console.log("combo: ", combo);
-                                this.tokens[columnInspector].moveTo(combo);
+                if(!this.tokens[columnInspector].matched) {
+                    let combo = columnInspector+1;
+                    for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
+                        if(!this.tokens[combo].matched) { 
+                            break; 
                         }
+                        else {
+                            console.log("combo: ", combo);
+                            this.tokens[columnInspector].moveTo(combo);
+                        }
+                    }
                 }
             }
-            //tween there
 
             this.tokens.forEach(token => {
                 token.matched = false;
             })
-
-            // this.tokens = [...matchedTokens, ...unmatchedTokens];
-            // console.log(this.tokens);
-            // for(var i = 0; i < this.columnSize; i++) {
-            //     this.tokens[i].y = (this.availHeight / (this.columnSize/i));
-            //     this.tokens[i]._verticalIndex = i;
-            // }
-
-            //this.revealMatches();
     }
 
     public hideMatches(): void {

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -4,8 +4,7 @@ import { Token } from "./token";
 
 export class Column extends Container{
 
-    public tokens: Token[];
-    public tokens: Token[];
+    public tokens: Token[] = [];
     private columnID: number;
     private columnSize: number;
 
@@ -16,7 +15,6 @@ export class Column extends Container{
         this.columnID = columnID;
         this.columnSize = columnSize;
 
-        this.tokens = [];
         for(var i = 0; i < this.columnSize; i++) {
             const randomNumber = Math.round(Math.random() * (9 - 1) + 1);
 
@@ -27,6 +25,9 @@ export class Column extends Container{
             this.addChild(newToken);
         }
     }
+
+
+
 
     public removeAllTokens(): void {
         this.tokens = [];

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -41,10 +41,8 @@ export class Column extends Container{
                 nonMatchCombo.unshift(target);
                 for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
                     if(!this.tokens[combo].matched){ break; }
-                    if(this.tokens[combo].matched) { 
-                        for(let i = 0; i < nonMatchCombo.length; i++){
-                            nonMatchCombo[i].moveTo(combo-i);
-                        }
+                    for(let i = 0; i < nonMatchCombo.length; i++){
+                        nonMatchCombo[i].moveTo(combo-i);
                     }
                 }
             }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -5,6 +5,7 @@ import { Token } from "./token";
 export class Column extends Container{
 
     public tokens: Token[];
+    public tokens: Token[];
     private columnID: number;
     private columnSize: number;
 
@@ -33,9 +34,11 @@ export class Column extends Container{
 
     public replaceAllTokens(newTokens: Token[]): void {
         if(newTokens.length != this.tokens.length) {
-            console.log("error on replaceAllTokens: input length does not match");
             return;
         }
     }
 
+    public getToken(Y: number) {
+        return this.tokens[Y];
+    }
 }

--- a/src/scripts/core/models/column.ts
+++ b/src/scripts/core/models/column.ts
@@ -40,7 +40,7 @@ export class Column extends Container{
             if(!target.matched) {
                 nonMatchCombo.unshift(target);
                 for(let combo = columnInspector+1; combo <= this.tokens.length-1; combo++) {
-                    if(this.tokens[combo].matched){ break; }
+                    if(!this.tokens[combo].matched){ break; }
                     if(this.tokens[combo].matched) { 
                         for(let i = 0; i < nonMatchCombo.length; i++){
                             nonMatchCombo[i].moveTo(combo-i);

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -31,11 +31,13 @@ export class Grid extends Container {
 
         //on FirstClick
         if(!this.selectedTokens[0]) {
+        if(!this.selectedTokens[0]) {
             this.selectedTokens[0] = targetToken;
             return;
         }
 
         //on SecondClick
+        if(this.selectedTokens[0] && !this.selectedTokens[1]) {
         if(this.selectedTokens[0] && !this.selectedTokens[1]) {
             this.selectedTokens[1] = targetToken;
             const firstSkIndex = this.selectedTokens[0].skIndex;
@@ -44,6 +46,7 @@ export class Grid extends Container {
             this.selectedTokens[1].setToken(firstSkIndex);
             this.selectedTokens = [undefined, undefined];
             this.resolveMatches();
+            this.selectedTokens[0], this.selectedTokens[1] = undefined;
             this.selectedTokens[0], this.selectedTokens[1] = undefined;
             return;
         }
@@ -58,6 +61,9 @@ export class Grid extends Container {
         this.columns.forEach(column => {
             this.matchLine(column.tokens);
         })
+
+
+
         //X Matches
         for(var i = 0; i < this.gridSize; i++) {
             const horizontalArray: Token [] = [];

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -6,9 +6,8 @@ import { Token } from "./token";
 export class Grid extends Container {
 
     private gridSize: number;
-    private columns: Column[];
-    private activeToken: number;
-    private firstTokenLocation: number[];
+    private columns: Column[] = [];
+    private selectedTokens: [Token | undefined, Token | undefined] = [undefined, undefined];
 
     constructor (gridSize: number, availWidth: number) {
         super ()
@@ -16,10 +15,6 @@ export class Grid extends Container {
         eventEmitter.on('clickCheck', this.clickCheck, this)
 
         this.gridSize = gridSize;
-        this.columns = [];
-        this.activeToken = 0;
-        const firstTokenLocation = [-1, -1];
-        this.firstTokenLocation = firstTokenLocation;
 
         for(var i = 0; i < this.gridSize; i++) {
             const newColumn = new Column(i, this.gridSize, availWidth, availWidth);
@@ -33,144 +28,107 @@ export class Grid extends Container {
     }
 
     private clickCheck(targetToken: Token): void {
-        //on first click, despite being defined in the constructor, activeToken appears undefined
-        if(this.activeToken === undefined) {
-            this.activeToken = 0;
-        }
 
         //on FirstClick
-        if((this.activeToken === 0) && (this.firstTokenLocation[0] === -1) && (this.firstTokenLocation[0] === -1)) {
-            targetToken.highLight();
-            this.activeToken = 1;
-            this.firstTokenLocation = targetToken.getLocation();
+        if(!this.selectedTokens[0]) {
+            this.selectedTokens[0] = targetToken;
             return;
         }
 
         //on SecondClick
-        if(this.activeToken === 1) {
-            targetToken.highLight();
-            this.activeToken = 2;
-
-            //Identify first Token
-            const firstX = this.firstTokenLocation[0];
-            const firstY = this.firstTokenLocation[1];
-            const firstTokenCopy = this.getToken(firstX, firstY);
-            const firstSkIndex = firstTokenCopy.getSkIndex();
-
-            //Identify second Token
-            const secondX = targetToken.getLocation()[0];
-            const secondY = targetToken.getLocation()[1];
-            const secondSkIndex = this.getToken(secondX, secondY).getSkIndex();
-
-            // //Swap Tokens
-            const tempFirstToken = this.getToken(firstX, firstY);
-            const tempSecondToken = this.getToken(secondX, secondY);
-            
-
-            //Swapping isn't working as expected
-            let targetFirst = this.getToken(firstX, firstY);
-            targetFirst.setToken(secondSkIndex);
-            let targetSecond = this.getToken(secondX, secondY);
-            targetSecond.setToken(firstSkIndex);
-
-            this.matchCheck(this.getToken(firstX, firstY));
-            this.matchCheck(this.getToken(secondX, secondY));
-
-            this.nukeBoard();
-
-            this.firstTokenLocation = [-1, -1];
-            this.activeToken = 0;
+        if(this.selectedTokens[0] && !this.selectedTokens[1]) {
+            this.selectedTokens[1] = targetToken;
+            const firstSkIndex = this.selectedTokens[0].skIndex;
+            const secondSkIndex = this.selectedTokens[1].skIndex;
+            this.selectedTokens[0].setToken(secondSkIndex);
+            this.selectedTokens[1].setToken(firstSkIndex);
+            this.selectedTokens = [undefined, undefined];
+            this.resolveMatches();
+            this.selectedTokens[0], this.selectedTokens[1] = undefined;
             return;
         }
 
     }
 
     /**
-     * Using target token, search horizontally and vertically for adjacent matching tokens
-     * Add those tokens to arrays and mark the tokens for later removal
+     * Use the matchLine function to find matches on columns and then rows
      */
-
-    private matchCheck(inputToken: Token): void {
-
-        const origin = inputToken;
-        const originX = origin.getLocation()[0];
-        const originY = origin.getLocation()[1];
-        let xMatches = []; 
-        xMatches.push(origin);
-        let yMatches = []; 
-        yMatches.push(origin);
-
-        //check token's right
-        for(let i = originX+1; i <= this.gridSize-1; i++) {
-            if(!this.isMatch(origin, this.getToken(i, originY))) {
-                break;
-            }
-            xMatches.push(this.getToken(i, originY))
-        }
-
-        //token's left
-        for(let i = originX-1; i >= 0; i--) {
-            if(!this.isMatch(origin, this.getToken(i, originY))) {
-                break;
-            }
-            xMatches.push(this.getToken(i, originY))
-        }
-
-        //beneath token
-        for(let i = originY+1; i <= this.gridSize-1; i++) {
-            if(!this.isMatch(origin, this.getToken(originX, i))) {
-                break;
-            }
-            yMatches.push(this.getToken(originX, i))
-        }
-
-        //above token
-        for(let i = originY-1; i >= 0; i--) {
-            if(!this.isMatch(origin, this.getToken(originX, i))) {
-                break;
-            }
-            yMatches.push(this.getToken(originX, i))
-        }
-
-        if(xMatches.length >= 3) {
-            this.markMatchedTokens(xMatches);
-        }
-        if(yMatches.length >= 3) {
-            this.markMatchedTokens(yMatches);
-        }
-
-    }
-
-    private getToken(X: number, Y: number): Token {
-        return this.columns[X].getToken(Y);
-    }
-
-    private markMatchedTokens(inputTokens: Token[]): void {
-        inputTokens.forEach(element => {
-            element.matched = true;
-        });
-    }
-
-    private isMatch(originToken: Token, comparisonToken: Token): boolean {
-        if(originToken.getSkIndex() === comparisonToken.getSkIndex()) {
-            return true;
-        }
-        else {
-            return false;
+    private resolveMatches(): void {
+        //Y Matches
+        this.columns.forEach(column => {
+            this.matchLine(column.tokens);
+        })
+        //X Matches
+        for(var i = 0; i < this.gridSize; i++) {
+            const horizontalArray: Token [] = [];
+            this.columns.forEach(column => {
+                horizontalArray.push (column.tokens[i]);
+            })
+            this.matchLine(horizontalArray);
         }
     }
 
     /**
-     * search the board for tokens found to be in a matching position
-     * reassemble the column
-     * Unmatches tokens shoud be at the bottom of the column
-     * Matching tokens should be at the top of the column with randomised skins.
+     * Identifies rows/columns of tokens where there are at least
+     * 3 adjacent to eachother.
+     * 
+     * Identified tokens are marked with highLight()
+     * and their matched status is set
+     * 
+     * @param Token[] - Array of Tokens to be searched for matches
      */
-    private nukeBoard(): void {
-        this.columns.forEach(column => {
-            column.veryCoolTokenReplacement();
-        })
+    private matchLine(tokens: Token[]) {
+        let cacheSkIndex: number | undefined = undefined;
+        let currentComboTokens: Token[] = [];
+        const totalComboTokens: Token[] = [];
 
+        function checkForCombo(): void {
+            if(currentComboTokens.length >= 3 ){
+                currentComboTokens.forEach(comboToken => {
+                    totalComboTokens.push(comboToken);
+                })
+            }
+        }
+
+        tokens.forEach(token => {
+            //new token
+            if(!cacheSkIndex) {
+                cacheSkIndex = token.skIndex;
+                currentComboTokens.push(token);
+                return;
+            }
+
+            //matching token
+            if(token.skIndex === cacheSkIndex) {
+                currentComboTokens.push(token);
+                return;
+            }
+
+            //last token in the array
+            if(token === tokens[this.gridSize-1]) {
+                checkForCombo();
+                return;
+            }
+
+            //cache defined but match failed
+            if(token.skIndex !== cacheSkIndex){
+                checkForCombo();
+                currentComboTokens = [];
+                cacheSkIndex = token.skIndex;
+                currentComboTokens.push(token);
+                return;
+            }
+        });
+
+        totalComboTokens.forEach(matchedToken => {
+            matchedToken.highLight();
+            matchedToken.matched = true;
+        })
+        
+    }
+
+    private getToken(X: number, Y: number): Token {
+        return this.columns[X].getToken(Y);
     }
 
 }

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -31,14 +31,12 @@ export class Grid extends Container {
 
         //on FirstClick
         if(!this.selectedTokens[0]) {
-        if(!this.selectedTokens[0]) {
             targetToken.highLight();
             this.selectedTokens[0] = targetToken;
             return;
         }
 
         //on SecondClick
-        if(this.selectedTokens[0] && !this.selectedTokens[1]) {
         if(this.selectedTokens[0] && !this.selectedTokens[1]) {
             targetToken.highLight();
             this.selectedTokens[1] = targetToken;

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -32,6 +32,7 @@ export class Grid extends Container {
         //on FirstClick
         if(!this.selectedTokens[0]) {
         if(!this.selectedTokens[0]) {
+            targetToken.highLight();
             this.selectedTokens[0] = targetToken;
             return;
         }
@@ -39,6 +40,7 @@ export class Grid extends Container {
         //on SecondClick
         if(this.selectedTokens[0] && !this.selectedTokens[1]) {
         if(this.selectedTokens[0] && !this.selectedTokens[1]) {
+            targetToken.highLight();
             this.selectedTokens[1] = targetToken;
             const firstSkIndex = this.selectedTokens[0].skIndex;
             const secondSkIndex = this.selectedTokens[1].skIndex;

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -45,9 +45,10 @@ export class Grid extends Container {
             this.selectedTokens[0].setToken(secondSkIndex);
             this.selectedTokens[1].setToken(firstSkIndex);
             this.selectedTokens = [undefined, undefined];
+            this.selectedTokens[0], this.selectedTokens[1] = undefined;
+            this.selectedTokens[0], this.selectedTokens[1] = undefined;
+
             this.resolveMatches();
-            this.selectedTokens[0], this.selectedTokens[1] = undefined;
-            this.selectedTokens[0], this.selectedTokens[1] = undefined;
             return;
         }
 
@@ -57,21 +58,27 @@ export class Grid extends Container {
      * Use the matchLine function to find matches on columns and then rows
      */
     private resolveMatches(): void {
-        //Y Matches
-        this.columns.forEach(column => {
-            this.matchLine(column.tokens);
-        })
+        // //Y Matches
+        // this.columns.forEach(column => {
+        //     column.tokens = this.matchLine(column.tokens);
+        // })
+        // //X Matches
+        // for(var i = 0; i < this.gridSize; i++) {
+        //     let horizontalArray: Token [] = [];
+        //     this.columns.forEach(column => {
+        //         horizontalArray.push (column.tokens[i]);
+        //     })
+        //     horizontalArray = this.matchLine(horizontalArray);
+        // }
 
+        // //Animate the board using detected matches
+        // this.columns.forEach(column => {
+        //     column.processMatches();
+        // })
 
-
-        //X Matches
-        for(var i = 0; i < this.gridSize; i++) {
-            const horizontalArray: Token [] = [];
-            this.columns.forEach(column => {
-                horizontalArray.push (column.tokens[i]);
-            })
-            this.matchLine(horizontalArray);
-        }
+        this.columns[0].tokens = this.matchLine(this.columns[0].tokens);
+        this.columns[0].processMatches();
+        this.columns[0].tokens.forEach(token => {token.matched = false;})
     }
 
     /**
@@ -83,7 +90,7 @@ export class Grid extends Container {
      * 
      * @param Token[] - Array of Tokens to be searched for matches
      */
-    private matchLine(tokens: Token[]) {
+    private matchLine(tokens: Token[]): Token [] {
         let cacheSkIndex: number | undefined = undefined;
         let currentComboTokens: Token[] = [];
         const totalComboTokens: Token[] = [];
@@ -107,7 +114,6 @@ export class Grid extends Container {
             //matching token
             if(token.skIndex === cacheSkIndex) {
                 currentComboTokens.push(token);
-                return;
             }
 
             //last token in the array
@@ -126,10 +132,15 @@ export class Grid extends Container {
             }
         });
 
-        totalComboTokens.forEach(matchedToken => {
-            matchedToken.highLight();
-            matchedToken.matched = true;
-        })
+        tokens.forEach(token => {
+            totalComboTokens.forEach(comboToken => {
+                if(token === comboToken) {
+                    token.matched = true;
+                }
+            });
+        });
+
+        return tokens;
         
     }
 

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -22,9 +22,7 @@ export class Grid extends Container {
             this.columns.push(newColumn);
             this.addChild(newColumn);
         }
-        
         this.position.set(this.getToken(0,0).width * 0.5, this.getToken(0,0).height * 0.5);
-
     }
 
     private clickCheck(targetToken: Token): void {
@@ -47,7 +45,6 @@ export class Grid extends Container {
             this.selectedTokens = [undefined, undefined];
             this.selectedTokens[0], this.selectedTokens[1] = undefined;
             this.selectedTokens[0], this.selectedTokens[1] = undefined;
-
             this.resolveMatches();
             return;
         }
@@ -110,18 +107,15 @@ export class Grid extends Container {
                 currentComboTokens.push(token);
                 return;
             }
-
             //matching token
             if(token.skIndex === cacheSkIndex) {
                 currentComboTokens.push(token);
             }
-
             //last token in the array
             if(token === tokens[this.gridSize-1]) {
                 checkForCombo();
                 return;
             }
-
             //cache defined but match failed
             if(token.skIndex !== cacheSkIndex){
                 checkForCombo();
@@ -141,15 +135,9 @@ export class Grid extends Container {
         });
 
         return tokens;
-        
     }
 
     private getToken(X: number, Y: number): Token {
         return this.columns[X].getToken(Y);
     }
-
-}
-    
-  
-
-    
+}    

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -58,27 +58,28 @@ export class Grid extends Container {
      * Use the matchLine function to find matches on columns and then rows
      */
     private resolveMatches(): void {
-        // //Y Matches
-        // this.columns.forEach(column => {
-        //     column.tokens = this.matchLine(column.tokens);
-        // })
-        // //X Matches
-        // for(var i = 0; i < this.gridSize; i++) {
-        //     let horizontalArray: Token [] = [];
-        //     this.columns.forEach(column => {
-        //         horizontalArray.push (column.tokens[i]);
-        //     })
-        //     horizontalArray = this.matchLine(horizontalArray);
-        // }
+        //Y Matches
+        this.columns.forEach(column => {
+            column.tokens = this.matchLine(column.tokens);
+        })
+        //X Matches
+        for(var i = 0; i < this.gridSize; i++) {
+            let horizontalArray: Token [] = [];
+            this.columns.forEach(column => {
+                horizontalArray.push (column.tokens[i]);
+            })
+            horizontalArray = this.matchLine(horizontalArray);
+        }
 
-        // //Animate the board using detected matches
-        // this.columns.forEach(column => {
-        //     column.processMatches();
-        // })
+        //Animate the board using detected matches
+        this.columns.forEach(column => {
+            column.processMatches();
+        })
 
-        this.columns[0].tokens = this.matchLine(this.columns[0].tokens);
-        this.columns[0].processMatches();
-        this.columns[0].tokens.forEach(token => {token.matched = false;})
+        //Only use the first Column for testing
+        // this.columns[0].tokens = this.matchLine(this.columns[0].tokens);
+        // this.columns[0].processMatches();
+        // this.columns[0].tokens.forEach(token => {token.matched = false;})
     }
 
     /**

--- a/src/scripts/core/models/grid.ts
+++ b/src/scripts/core/models/grid.ts
@@ -167,36 +167,9 @@ export class Grid extends Container {
      * Matching tokens should be at the top of the column with randomised skins.
      */
     private nukeBoard(): void {
-        function isMatched(token: Token) {
-            return (token.matched);
-        }
-
-        function isNotMatched(token: Token) {
-            return (!token.matched);
-        }
-
-        this.columns.forEach(targetColumn => {
-            
-            const newTokenArray = targetColumn.getAllTokens();
-
-            const matched = targetColumn.getAllTokens().filter(isMatched);
-            matched.forEach(token => {
-                token.shuffleSkin();
-                token.highLight();
-                newTokenArray.push(token);
-            });
-
-            const unmatched = targetColumn.getAllTokens().filter(isNotMatched);
-            unmatched.forEach(token => {
-                newTokenArray.push(token);
-            });
-
-            newTokenArray.forEach(token => {
-                token.matched = false;
-            })
-
-            targetColumn.replaceAllTokens(newTokenArray);
-        });
+        this.columns.forEach(column => {
+            column.veryCoolTokenReplacement();
+        })
 
     }
 

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -78,6 +78,13 @@ export class Token extends Container {
         });
     }
 
+    public hide(): void {
+        gsap.to(this, {
+            alpha: 0,
+            duration: 0.3
+        });
+    }
+
     // private wobble(): void {
     //     if(this.skIndex === 1){
     //         gsap.to(this, {

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -7,23 +7,21 @@ import { gsap } from 'gsap';
 export class Token extends Container {
 
     public matched: boolean;
-    private parentID: number;
-    private locationIndex;
+    public parentID: number;
+    public horizontalIndex;
     private skin: Spine;
-    private skIndex: number;
+    public skIndex: number;
 
 
-    constructor (parentID: number, locationIndex: number, size: number, skIndex: number, availWidth: number) {
+    constructor (parentID: number, horizontalIndex: number, size: number, skIndex: number, availWidth: number) {
         super();
 
         this.on('pointerdown', this.onClicked)
-        //eventEmitter.on('tokenFirstClicked', this.onClicked);
-        //eventEmitter.on('tokenSecondClicked', this.onClicked);
 
         this.matched = false;
         this.interactive = true;
         this.parentID = parentID;
-        this.locationIndex = locationIndex;
+        this.horizontalIndex = horizontalIndex;
         this.skIndex = skIndex;
         this.skin = new Spine(Assets.get('symbols').spineData);
         this.skin.skeleton.setSkinByName(`${this.skIndex}`);
@@ -33,34 +31,21 @@ export class Token extends Container {
         this.addChild(this.skin);
     }
 
-    setToken(skIndex: number) {
-        this.skIndex = skIndex;
-        this.skin.skeleton.setSkinByName(`${skIndex}`);
-    }
-
-    //onClicked
     public onClicked(): void {
         eventEmitter.emit('clickCheck', this);
+    }
+
+    public setToken(skIndex: number) {
+        this.skIndex = skIndex;
+        this.skin.skeleton.setSkinByName(`${skIndex}`);
     }
 
     public onTokenReveal(arg: number): void {
     }
 
-    public getParentID(): number {
-        return this.parentID;
-    }
-
     public getLocation(): number[] {
-        const location = [this.parentID, this.locationIndex];
+        const location = [this.parentID, this.horizontalIndex];
         return location;
-    }
-
-    public getSkIndex(): number {
-        return this.skIndex;
-    }
-
-    public setSkIndex(newSkIndex: number): void {
-        this.skIndex = newSkIndex;
     }
 
     public shuffleSkin(): void {

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -19,7 +19,7 @@ export class Token extends Container {
         return this._parentID;
     }
 
-    constructor (parentID: number, verticalIndex: number, size: number, skIndex: number, availWidth: number, availHeight: number) {
+    constructor (parentID: number, verticalIndex: number, size: number, availWidth: number, availHeight: number) {
         super();
 
         this.on('pointerdown', this.onClicked)
@@ -31,7 +31,7 @@ export class Token extends Container {
         this._verticalIndex = verticalIndex;
         this.availWidth = availWidth;
         this.availHeight = availHeight;
-        this.skIndex = skIndex;
+        this.skIndex = Math.round(Math.random() * (9 - 1) + 1);;
         this.skin = new Spine(Assets.get('symbols').spineData);
         this.skin.skeleton.setSkinByName(`${this.skIndex}`);
         this.width = Math.ceil(this.skin.width)

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -7,21 +7,29 @@ import { gsap } from 'gsap';
 export class Token extends Container {
 
     public matched: boolean;
-    public parentID: number;
-    public horizontalIndex;
+    private _parentID: number;
+    private _verticalIndex: number;
     private skin: Spine;
     public skIndex: number;
 
+    public get parentID() {
+        return this._parentID;
+    }
 
-    constructor (parentID: number, horizontalIndex: number, size: number, skIndex: number, availWidth: number) {
+    public get verticalIndex() {
+        return this._verticalIndex;
+    }
+
+
+    constructor (parentID: number, verticalIndex: number, size: number, skIndex: number, availWidth: number) {
         super();
 
         this.on('pointerdown', this.onClicked)
 
         this.matched = false;
         this.interactive = true;
-        this.parentID = parentID;
-        this.horizontalIndex = horizontalIndex;
+        this._parentID = parentID;
+        this._verticalIndex = verticalIndex;
         this.skIndex = skIndex;
         this.skin = new Spine(Assets.get('symbols').spineData);
         this.skin.skeleton.setSkinByName(`${this.skIndex}`);
@@ -44,7 +52,7 @@ export class Token extends Container {
     }
 
     public getLocation(): number[] {
-        const location = [this.parentID, this.horizontalIndex];
+        const location = [this.parentID, this._verticalIndex];
         return location;
     }
 
@@ -69,25 +77,5 @@ export class Token extends Container {
             duration: 0.3
         });
     }
-
-    // private wobble(): void {
-    //     if(this.skIndex === 1){
-    //         gsap.to(this, {
-    //            rotation: 2,
-    //            repeat: -1,
-    //             yoyo: true,
-    //             duration: 1
-    //         })
-    //     }
-    // }
-
-    // private fade(): void {
-    //     gsap.to(this, {
-    //         alpha: 0.1,
-    //         repeat: -1,
-    //          yoyo: true,
-    //          duration: 1
-    //      })
-    // }
 
 }

--- a/src/scripts/core/models/token.ts
+++ b/src/scripts/core/models/token.ts
@@ -8,7 +8,10 @@ export class Token extends Container {
 
     public matched: boolean;
     private _parentID: number;
-    private _verticalIndex: number;
+    private parentSize: number;
+    public _verticalIndex: number;
+    private availWidth: number;
+    private availHeight: number;
     private skin: Spine;
     public skIndex: number;
 
@@ -16,12 +19,7 @@ export class Token extends Container {
         return this._parentID;
     }
 
-    public get verticalIndex() {
-        return this._verticalIndex;
-    }
-
-
-    constructor (parentID: number, verticalIndex: number, size: number, skIndex: number, availWidth: number) {
+    constructor (parentID: number, verticalIndex: number, size: number, skIndex: number, availWidth: number, availHeight: number) {
         super();
 
         this.on('pointerdown', this.onClicked)
@@ -29,7 +27,10 @@ export class Token extends Container {
         this.matched = false;
         this.interactive = true;
         this._parentID = parentID;
+        this.parentSize = size;
         this._verticalIndex = verticalIndex;
+        this.availWidth = availWidth;
+        this.availHeight = availHeight;
         this.skIndex = skIndex;
         this.skin = new Spine(Assets.get('symbols').spineData);
         this.skin.skeleton.setSkinByName(`${this.skIndex}`);
@@ -63,19 +64,43 @@ export class Token extends Container {
     }
 
     public highLight(): void {
-        gsap.to(this, {
-            alpha: 0.5,
-            repeat: 3,
-            yoyo: true,
-            duration: 0.3
-        });
+        let highLight = gsap.timeline({repeat: 2, yoyo: true});
+        const cacheWidth = this.width;
+        highLight.to(this, {
+            width: 0
+        })
+        highLight.to(this, {
+            width: cacheWidth
+        })
     }
 
     public hide(): void {
         gsap.to(this, {
-            alpha: 0,
+            alpha: 0.001,
             duration: 0.3
         });
+    }
+
+    public reveal(): void {
+        gsap.to(this, {
+            alpha: 1,
+            duration: 0.3
+        });
+    }
+
+    public moveTo(desiredArrayPosition: number): void {
+        const TargetLocation = (this.availHeight / (this.parentSize/desiredArrayPosition));
+        gsap.to(this, {
+            y: TargetLocation,
+            duration: 1
+        })
+    }
+
+    public testMoveTo(): void {
+        gsap.to(this, {
+        y: this.height,
+        duration: 1  
+        })
     }
 
 }

--- a/src/scripts/scene.ts
+++ b/src/scripts/scene.ts
@@ -47,7 +47,7 @@ export class Scene extends Container {
 
         // discern portrait/landscape
 
-        const grid = new Grid(5, this.gridWidth);
+        const grid = new Grid(6, this.gridWidth);
         this.addChild(grid);
     }
 

--- a/src/scripts/scene.ts
+++ b/src/scripts/scene.ts
@@ -1,11 +1,9 @@
-//import { Spine } from 'pixi-spine';
 import { Assets, Container } from 'pixi.js'
 import { Grid } from './core/models/grid';
 
 export class Scene extends Container {
     private viewWidth: number;
     private viewHeight: number;
-    //private spine!: Spine;
     private assets: any[] = [];
     private gridWidth: number;
 
@@ -21,7 +19,6 @@ export class Scene extends Container {
         else { 
             this.gridWidth = this.viewHeight; 
         }
-
     }
 
     public async load(): Promise<void> {
@@ -35,18 +32,9 @@ export class Scene extends Container {
             const loadedAsset = await Assets.load(asset.key);
             this.assets.push(loadedAsset);
         }
-
     }
 
     public initialise(): void {
-        // this.spine = new Spine(Assets.get('symbols').spineData);
-        // this.spine.skeleton.setSkinByName('1');
-        // this.spine.x = this.viewWidth * 0.5;
-        // this.spine.y = this.viewHeight * 0.5;
-        // this.addChild(this.spine);
-
-        // discern portrait/landscape
-
         const grid = new Grid(6, this.gridWidth);
         this.addChild(grid);
     }


### PR DESCRIPTION
Column class can now manipulate Tokens identified through Grid's matchLine.

Columns hide Tokens and set them to be none-interactive. The Column then re-structures its array to match the state displayed on the board in preparation for following matches.

Known Issues:
Token Swap rotation is still a placeholder and may produce strange behavior on rapid matching.
Currently there is no mechanism for guaranteeing a fully clearable board.