### PR TITLE
No high score reset

### DIFF
--- a/src/scripts/main.ts
+++ b/src/scripts/main.ts
@@ -7,6 +7,4 @@ export const Game = new Engine({
     canvasH: 450
 });
 
-localStorage.highScore = 0;
-
 Game.initialise(new MenuScene(Game.width, Game.height));

--- a/src/scripts/scenes/sceneObjects/game-scene-object-loader.ts
+++ b/src/scripts/scenes/sceneObjects/game-scene-object-loader.ts
@@ -70,7 +70,7 @@ export class GameSceneObjectLoader extends SceneObjectLoader{
         this.addChild(this._menuButton);
 
 
-        this._timer = new Timer(3, 
+        this._timer = new Timer(90, 
         {
             /**This is where you can add in callbacks for things happening
              * as the timer runs down


### PR DESCRIPTION
Changed the game timer to 90 seconds to make the game playable.

Locally scored highscore is no longer removed on browser refresh